### PR TITLE
internal/version: use stirngs.Builder

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of the Midgard",
 	Long:  `Print the version number of the Midgard`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version.Version)
+		fmt.Println(version.String())
 	},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of the Midgard",
 	Long:  `Print the version number of the Midgard`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version.String())
+		fmt.Println(version.Version)
 	},
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -23,11 +23,11 @@ func String() string {
 	if GitVersion == "" {
 		GitVersion = "devel"
 	}
-	var B = new(strings.Builder)
-	fmt.Fprintf(B, "Version:     %s\n", GitVersion)
-	fmt.Fprintf(B, "Go version:  %s\n", GoVersion)
+	var b = new(strings.Builder)
+	fmt.Fprintf(b, "Version:     %s\n", GitVersion)
+	fmt.Fprintf(b, "Go version:  %s\n", GoVersion)
 	if BuildTime != "" {
-		fmt.Fprintf(B, "Build time:  %s\n", BuildTime)
+		fmt.Fprintf(b, "Build time:  %s\n", BuildTime)
 	}
-	return B.String()
+	return b.String()
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,6 +10,10 @@ import (
 	"strings"
 )
 
+// Version is a newline-terminated string describing the current
+// version of the build.
+var Version string
+
 // These strings will be overwritten at built time.
 var (
 	GitVersion string
@@ -17,9 +21,7 @@ var (
 	BuildTime  string
 )
 
-// String returns a newline-terminated string describing the current
-// version of the build.
-func String() string {
+func init() {
 	if GitVersion == "" {
 		GitVersion = "devel"
 	}
@@ -29,5 +31,5 @@ func String() string {
 	if BuildTime != "" {
 		fmt.Fprintf(b, "Build time:  %s\n", BuildTime)
 	}
-	return b.String()
+	Version = b.String()
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 )
 
-// Version is a newline-terminated string describing the current
+// version is a newline-terminated string describing the current
 // version of the build.
-var Version string
+var version string
 
 // These strings will be overwritten at built time.
 var (
@@ -31,5 +31,11 @@ func init() {
 	if BuildTime != "" {
 		fmt.Fprintf(b, "Build time:  %s\n", BuildTime)
 	}
-	Version = b.String()
+	version = b.String()
+}
+
+// String returns a newline-terminated string describing the current
+// version of the build.
+func String() string {
+	return version
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,6 +7,7 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 // These strings will be overwritten at built time.
@@ -22,10 +23,11 @@ func String() string {
 	if GitVersion == "" {
 		GitVersion = "devel"
 	}
-	str := fmt.Sprintf("Vrsion:      %s\n", GitVersion)
-	str += fmt.Sprintf("Go version:  %s\n", GoVersion)
+	var B = new(strings.Builder)
+	fmt.Fprintf(B, "Version:     %s\n", GitVersion)
+	fmt.Fprintf(B, "Go version:  %s\n", GoVersion)
 	if BuildTime != "" {
-		str += fmt.Sprintf("Build time:  %s\n", BuildTime)
+		fmt.Fprintf(B, "Build time:  %s\n", BuildTime)
 	}
-	return str
+	return B.String()
 }


### PR DESCRIPTION
可以试试用 `strings.Builder`，配上 `fmt.Fprint` 系列真的很好用。
具体的我不太懂，用 Builder 应该比字符串加等更好吧。
PS：大佬 25 行好像写错字了……

Recommand to use `strings.Builder` and `fmt.Fprint`.
I guess it's better than use string directly.