### PR TITLE
cmd/alloc: allocated URL to clipboard does not work on Linux

### DIFF
--- a/cmd/alloc.go
+++ b/cmd/alloc.go
@@ -10,10 +10,7 @@ import (
 	"log"
 
 	"changkun.de/x/midgard/api/daemon"
-	"changkun.de/x/midgard/internal/clipboard"
-	"changkun.de/x/midgard/internal/types"
 	"changkun.de/x/midgard/internal/types/proto"
-	"changkun.de/x/midgard/internal/utils"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
 )
@@ -54,8 +51,8 @@ func allocate(dstpath, srcpath string) {
 				status.Convert(err).Message())
 		}
 		if out.URL != "" {
-			//block util clipboard is updated
-			clipboard.WriteAndWaitChange(types.MIMEPlainText, utils.StringToBytes(out.URL))
+			// Clipboard is updated on the daemon side, we don't have to
+			// write clipboard in the allocate command again, see PR#16.
 			fmt.Println(out.URL)
 		} else {
 			fmt.Printf("%v\n", out.Message)

--- a/cmd/alloc.go
+++ b/cmd/alloc.go
@@ -54,7 +54,8 @@ func allocate(dstpath, srcpath string) {
 				status.Convert(err).Message())
 		}
 		if out.URL != "" {
-			clipboard.Local.Write(types.MIMEPlainText, utils.StringToBytes(out.URL))
+			//block util clipboard is updated
+			clipboard.WriteAndWaitChange(types.MIMEPlainText, utils.StringToBytes(out.URL))
 			fmt.Println(out.URL)
 		} else {
 			fmt.Printf("%v\n", out.Message)

--- a/internal/clipboard/local.go
+++ b/internal/clipboard/local.go
@@ -82,3 +82,18 @@ func (lc *local) Watch(ctx context.Context, dt types.MIME) <-chan []byte {
 	}
 	return nil
 }
+
+// WriteAndWaitChange writes the given buffer to the clipboard and wait util clipboard is updated.
+// The reason do so is that Writing clipboard doesn't work when exiting immediately after
+// golang.design/x/clipboard.Write return which cause URL can't be written into clipboard
+// after allocation on my Linux device(Manjaro 21.0.2 with GNOME 3.38.5)
+func WriteAndWaitChange(t types.MIME, buf []byte) {
+	var ch <-chan struct{}
+	switch t {
+	case types.MIMEPlainText:
+		ch = clipboard.Write(clipboard.FmtText, buf)
+	case types.MIMEImagePNG:
+		ch = clipboard.Write(clipboard.FmtImage, buf)
+	}
+	<-ch
+}

--- a/internal/clipboard/local.go
+++ b/internal/clipboard/local.go
@@ -82,18 +82,3 @@ func (lc *local) Watch(ctx context.Context, dt types.MIME) <-chan []byte {
 	}
 	return nil
 }
-
-// WriteAndWaitChange writes the given buffer to the clipboard and wait util clipboard is updated.
-// The reason do so is that Writing clipboard doesn't work when exiting immediately after
-// golang.design/x/clipboard.Write return which cause URL can't be written into clipboard
-// after allocation on my Linux device(Manjaro 21.0.2 with GNOME 3.38.5)
-func WriteAndWaitChange(t types.MIME, buf []byte) {
-	var ch <-chan struct{}
-	switch t {
-	case types.MIMEPlainText:
-		ch = clipboard.Write(clipboard.FmtText, buf)
-	case types.MIMEImagePNG:
-		ch = clipboard.Write(clipboard.FmtImage, buf)
-	}
-	<-ch
-}


### PR DESCRIPTION
`clipboard.write` does't work  on my linux device when main goroutine exit immediately after it return, which cause allocated url can't be written into clipboard. So to fix it,  I make writing clipboard operation block util clipboard is updated to guarantee clipboard can be written into successfully.