### PR TITLE
lint fix

### DIFF
--- a/api/daemon/clipboard.go
+++ b/api/daemon/clipboard.go
@@ -23,7 +23,7 @@ import (
 func (m *Daemon) watchLocalClipboard(ctx context.Context) {
 	last := time.Now()
 	hotkey.Handle(ctx, func() {
-		if time.Now().Sub(last) < time.Second*5 {
+		if time.Since(last) < time.Second*5 {
 			log.Println("pressing hotkey too fast, ignoring")
 			return
 		}
@@ -31,7 +31,7 @@ func (m *Daemon) watchLocalClipboard(ctx context.Context) {
 
 		var msg string
 		defer func() {
-			log.Printf(msg)
+			log.Print(msg)
 			clipboard.Local.Write(
 				types.MIMEPlainText, utils.StringToBytes(msg))
 		}()

--- a/api/daemon/ws.go
+++ b/api/daemon/ws.go
@@ -62,7 +62,7 @@ func (m *Daemon) wsConnect() error {
 	wsm := &types.WebsocketMessage{}
 	err = wsm.Decode(msg)
 	if err != nil {
-		return fmt.Errorf("failed to handhsake with midgard server: %w", err)
+		return fmt.Errorf("failed to handshake with midgard server: %w", err)
 	}
 
 	switch wsm.Action {
@@ -73,7 +73,7 @@ func (m *Daemon) wsConnect() error {
 		}
 	default:
 		conn.Close() // close the connection if handshake is not ready
-		return fmt.Errorf("failed to handhsake with midgard server: %w", err)
+		return fmt.Errorf("failed to handshake with midgard server: %w", err)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,7 @@ type Server struct {
 // Daemon is the midgard daemon configuration
 type Daemon struct {
 	Addr   string `yaml:"addr"`
-	Server string `yaml:"serfver"`
+	Server string `yaml:"server"`
 }
 
 // S returns the midgard server configuration

--- a/internal/utils/copy.go
+++ b/internal/utils/copy.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 )
 
-// this implemnetation is derived from https://github.com/otiai10/copy.
+// this implementation is derived from https://github.com/otiai10/copy.
 
 // Copy copies src to dest, doesn't matter if src is a directory or a file.
 func Copy(src, dest string) error {

--- a/internal/utils/uuid.go
+++ b/internal/utils/uuid.go
@@ -16,7 +16,7 @@ import (
 )
 
 // random function
-var rander = rand.Reader
+var reader = rand.Reader
 
 var nilUUID uuid // empty UUID, all zeros
 
@@ -36,7 +36,7 @@ func (u uuid) String() string {
 // NewUUID creates a new uuid.
 func NewUUID() (uuid, error) {
 	var u uuid
-	_, err := io.ReadFull(rander, u[:])
+	_, err := io.ReadFull(reader, u[:])
 	if err != nil {
 		return nilUUID, err
 	}
@@ -141,7 +141,7 @@ func (b base57) Encode(u uuid) string {
 	return b.numToString(&num, int(length))
 }
 
-// numToString converts a number a string using the given alpabet.
+// numToString converts a number to string using the given alphabet.
 func (b *base57) numToString(number *big.Int, padToLen int) string {
 	var (
 		out   string

--- a/midgard.go
+++ b/midgard.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	// midgard cli involes graphical APIs that require midgard daemon to
+	// midgard cli involves graphical APIs that require midgard daemon to
 	// running on the main thread. Instead of executing the command center,
 	// initialize it from the golang.design/x/mainthread package.
 	mainthread.Init(cmd.Execute)


### PR DESCRIPTION
Some typo and lint fix.
But there is a breaking change at [here](https://github.com/changkun/midgard/blob/main/internal/config/config.go#L54)

``` go
type Daemon struct {
	Addr   string `yaml:"addr"`
	Server string `yaml:"server"` // <--
}
```

Daemon.Server's struct tag has changed.
But it looks like it's not being referenced. Maybe it can be removed?